### PR TITLE
Add java version to gradle upgrade workflow

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -16,6 +16,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'temurin'
+
       - name: Update Gradle Wrapper
         # **WARN**: as this action comes from the org without public members,
         # and it has relatively few "stars", so this specific SHA passed #infosec


### PR DESCRIPTION
This commit setting up the java version on the gradle upgrader workflow in attempt to ensure that version running during the upgrade is 17 (which is required for the project at this point as the minimal version of java)